### PR TITLE
Fix login not showing any error message

### DIFF
--- a/Volunteering/src/pages/Login.jsx
+++ b/Volunteering/src/pages/Login.jsx
@@ -32,7 +32,7 @@ export default function Login({
             });
             const data = await response.json();
 
-            if (!response.ok) throw new Error(data.message);
+            if (!response.ok) throw new Error(data.error);
 
             handleLogin(data);
             setEmail('');


### PR DESCRIPTION
Login form was checking the wrong field for an error message. Can't be bothered to bisect to find when this was introduced